### PR TITLE
add :::sic handling, --ignore-sic

### DIFF
--- a/cpan/hoonlint
+++ b/cpan/hoonlint
@@ -69,6 +69,7 @@ sub parseReportItems {
 }
 
 my $verbose;    # right now does nothing
+my $ignoreSic;
 my $inclusionsFileName;
 my @suppressionsFileNames;
 my @policiesArg;
@@ -84,6 +85,7 @@ GetOptions(
     "inclusions-file|I=s"   => \$inclusionsFileName,
     "suppressions_file|S=s" => \@suppressionsFileNames,
     "policy|P=s"            => \@policiesArg,
+    "ignore-sic|i"          => \$ignoreSic,
 ) or die("Error in command line arguments\n");
 
 sub usage {
@@ -163,6 +165,14 @@ for my $fileName (@fileNames) {
     $config{fileName} = $fileName;
     my $pHoonSource = slurp($fileName);
     $config{pHoonSource} = $pHoonSource;
+
+    my %skipLines = ();
+    if ( not defined $ignoreSic) {
+      # TODO I'm sure there's a fancy way to do this, using a grammar perhaps
+      %skipLines = map { int($_) => 1 } split '\n', `sed -n '/:::sic/=' $fileName`;
+    }
+    $config{skipLines} = \%skipLines;
+    $config{skipLinesUnused} = { %skipLines };
 
     my ( $suppressions, $unusedSuppressions ) =
       parseReportItems( \%config, $pSuppressions );

--- a/cpan/lib/MarpaX/Hoonlint.pm
+++ b/cpan/lib/MarpaX/Hoonlint.pm
@@ -374,6 +374,7 @@ sub reportItem {
 
     my $inclusions      = $instance->{inclusions};
     my $suppressions    = $instance->{suppressions};
+    my $skipLines       = $instance->{skipLines};
     my $reportPolicy    = $mistake->{policy};
 
     # TODO: Is subpolicy everywhere?  Can the tag
@@ -406,9 +407,15 @@ sub reportItem {
     $excludeThisItem = 1
       if $inclusions
       and not $inclusions->{$reportLC}{$reportPolicy}{$reportSubpolicy};
+
+    my $lineSkip = $skipLines->{$reportLine};
     my $suppression =
       $suppressions->{$reportLC}->{$reportPolicy}->{$reportSubpolicy};
-    if ( defined $suppression ) {
+    if ( defined $lineSkip ){
+        $suppressThisItem = 1;
+        delete $instance->{skipLinesUnused}->{$reportLine};
+    }
+    elsif ( defined $suppression ) {
         $suppressThisItem = 1;
         $instance->{unusedSuppressions}->{$reportLC}->{$reportPolicy}
           ->{$reportSubpolicy} = undef;
@@ -1079,6 +1086,10 @@ sub new {
                 say "Unused suppression: $fileName $lc $policy $subpolicy";
             }
         }
+    }
+    my $skipLinesUnused = $lintInstance->{skipLinesUnused};
+    for my $line ( keys %{$skipLinesUnused} ) {
+        say "Redundant :::sic in $fileName:$line";
     }
 
     return $lintInstance;

--- a/cpan/lib/MarpaX/Hoonlint.pm
+++ b/cpan/lib/MarpaX/Hoonlint.pm
@@ -398,7 +398,6 @@ sub reportItem {
     # been enforced.  This is a mistake and should change.
     # Add reportLine/reportColumn to all mistakes, and do not use
     # line/column.  (Can line/column be eliminated?)
-    my $parentLine       = $mistake->{parentLine} // -1;
     my $reportLine       = $mistake->{reportLine} // $mistake->{line};
     my $reportColumn     = $mistake->{reportColumn} // $mistake->{column};
     my $reportLC         = join ':', $reportLine, $reportColumn + 1;
@@ -409,17 +408,17 @@ sub reportItem {
       if $inclusions
       and not $inclusions->{$reportLC}{$reportPolicy}{$reportSubpolicy};
 
-    my $lineSkip = $skipLines->{$reportLine} // $skipLines->{$parentLine};
+    my $lineSkip = $skipLines->{$reportLine} && $reportLine;
+
+    if( ref($mistake->{topicLines}) && $mistake->{topicLines}[0]){
+      my $topicLine = $mistake->{topicLines}[0];
+      $lineSkip //= $skipLines->{$topicLine} && $topicLine;
+    }
     my $suppression =
       $suppressions->{$reportLC}->{$reportPolicy}->{$reportSubpolicy};
     if ( defined $lineSkip ){
         $suppressThisItem = 1;
-        if( defined $instance->{skipLinesUnused}->{$reportLine}){
-          delete $instance->{skipLinesUnused}->{$reportLine};
-        }
-        else {
-          delete $instance->{skipLinesUnused}->{$parentLine};
-        }
+        delete $instance->{skipLinesUnused}->{$lineSkip};
     }
     elsif ( defined $suppression ) {
         $suppressThisItem = 1;

--- a/cpan/lib/MarpaX/Hoonlint.pm
+++ b/cpan/lib/MarpaX/Hoonlint.pm
@@ -398,6 +398,7 @@ sub reportItem {
     # been enforced.  This is a mistake and should change.
     # Add reportLine/reportColumn to all mistakes, and do not use
     # line/column.  (Can line/column be eliminated?)
+    my $parentLine       = $mistake->{parentLine} // -1;
     my $reportLine       = $mistake->{reportLine} // $mistake->{line};
     my $reportColumn     = $mistake->{reportColumn} // $mistake->{column};
     my $reportLC         = join ':', $reportLine, $reportColumn + 1;
@@ -408,12 +409,17 @@ sub reportItem {
       if $inclusions
       and not $inclusions->{$reportLC}{$reportPolicy}{$reportSubpolicy};
 
-    my $lineSkip = $skipLines->{$reportLine};
+    my $lineSkip = $skipLines->{$reportLine} // $skipLines->{$parentLine};
     my $suppression =
       $suppressions->{$reportLC}->{$reportPolicy}->{$reportSubpolicy};
     if ( defined $lineSkip ){
         $suppressThisItem = 1;
-        delete $instance->{skipLinesUnused}->{$reportLine};
+        if( defined $instance->{skipLinesUnused}->{$reportLine}){
+          delete $instance->{skipLinesUnused}->{$reportLine};
+        }
+        else {
+          delete $instance->{skipLinesUnused}->{$parentLine};
+        }
     }
     elsif ( defined $suppression ) {
         $suppressThisItem = 1;


### PR DESCRIPTION
This code could be improved in a number of ways, starting from the backticked `sed` call; I don't have a strong sense of what is correct perl style, in general, but it does as they say work on my machine.